### PR TITLE
HashMap: allow valueIterable to be iterated more than once

### DIFF
--- a/src/HashMap.ts
+++ b/src/HashMap.ts
@@ -227,7 +227,10 @@ export class HashMap<K,V> implements IMap<K,V> {
      * to have equality in the generics type)
      */
     valueIterable(): Iterable<V> {
-        return <Iterable<V>>this.hamt.values();
+        const hamt = this.hamt;
+        return {
+            [Symbol.iterator]() { return hamt.values(); }
+        };
     }
 
     /**

--- a/tests/HashMap.ts
+++ b/tests/HashMap.ts
@@ -179,6 +179,11 @@ describe("hashmap extract values", () => {
         HashSet.empty<string>().equals(HashSet.ofIterable(HashMap.empty<string,string>().valueIterable()))));
     it("should get non-empty valueIterable", () => assert.ok(
         HashSet.of("b","d").equals(HashSet.ofIterable(HashMap.empty<string,string>().put("a","b").put("c","d").valueIterable()))));
+    it("should allow iteration of valueIterable more than once", () => {
+        const i = HashMap.empty<string, string>().put("a", "b").put("c", "d").valueIterable();
+        HashSet.of("b", "d").equals(HashSet.ofIterable(Array.from(i)));
+        HashSet.of("b", "d").equals(HashSet.ofIterable(Array.from(i)));
+    })
     it("supports iterator", () => {
         let total = 0;
         let letters = [];


### PR DESCRIPTION
Iterators are stateful and can't be reused.  Therefore, the iterator protocol
makes Iterable's contain a zero-argument function which creates a new iterator,
and re-calls this zero-argument function to create a new iterator every time
an iteration starts.

hamt.values() returns an iterator which is stateful, so it must be wrapped in
a zero-argument function to become an Iterable<T>.