### PR TITLE
Fix tests of Vector equality

### DIFF
--- a/tests/Vector.ts
+++ b/tests/Vector.ts
@@ -79,31 +79,13 @@ describe("Vector extra methods", () => {
     });
 });
 
-// that's needed due to node's assert.deepEqual
-// saying that new Array(2) is NOT the same as
-// [undefined, undefined].
-// (empty vs undefined)
-// => forcing undefined
-function arraySetUndefineds(ar:any[]) {
-    if (!ar) {return ar;}
-    for (let i=0;i<ar.length;i++) {
-        if (Array.isArray(ar[i])) {
-            arraySetUndefineds(ar[i]);
-        }
-        if (typeof ar[i] === "undefined") {
-            ar[i] = undefined;
-        }
-    }
-    return ar;
-}
-
 function checkTake<T>(longer: Vector<T>, n: number, shorter: Vector<T>) {
     const arrayBefore = longer.toArray();
-    assert.deepEqual(
-        arraySetUndefineds((<any>shorter)._contents),
-        (<any>longer.take(n))._contents);
+    assert.deepStrictEqual(
+        shorter.toArray(),
+        longer.take(n).toArray());
     // taking should not have modified the original vector
-    assert.deepEqual(arrayBefore, longer.toArray());
+    assert.deepStrictEqual(arrayBefore, longer.toArray());
 }
 
 // check that the internal structure of the vector trie
@@ -127,11 +109,11 @@ describe("Vector.take() implementation", () => {
 
 function checkAppend<T>(base: Vector<T>, toAppend: Iterable<T>, combined: Vector<T>) {
     const arrayBefore = base.toArray();
-    assert.deepEqual(
-        arraySetUndefineds((<any>combined)._content),
-        (<any>base.appendAll(toAppend))._content);
+    assert.deepStrictEqual(
+        combined.toArray(),
+        base.appendAll(toAppend).toArray());
     // appending should not have modified the original vector
-    assert.deepEqual(arrayBefore, base.toArray());
+    assert.deepStrictEqual(arrayBefore, base.toArray());
 }
 
 describe("Vector.appendAll() implementation", () => {
@@ -140,18 +122,18 @@ describe("Vector.appendAll() implementation", () => {
     });
     it("handles adding nodes correctly", () => {
         checkAppend(Vector.of(1,2,3), Stream.iterate(4,i=>i+1).take(70),
-                    Vector.ofIterable(Stream.iterate(0,i=>i+1).take(74)));
+                    Vector.ofIterable(Stream.iterate(1,i=>i+1).take(73)));
     });
     it("handles adding nodes correctly, adding an array", () => {
         checkAppend(Vector.of(1,2,3), Stream.iterate(4,i=>i+1).take(70).toArray(),
-                    Vector.ofIterable(Stream.iterate(0,i=>i+1).take(74)));
+                    Vector.ofIterable(Stream.iterate(1,i=>i+1).take(73)));
     });
     it("handles adding nodes correctly, adding a vector", () => {
         checkAppend(Vector.of(1,2,3), Stream.iterate(4,i=>i+1).take(70).toVector(),
-                    Vector.ofIterable(Stream.iterate(0,i=>i+1).take(74)));
+                    Vector.ofIterable(Stream.iterate(1,i=>i+1).take(73)));
     });
     it("handles large vectors at node boundaries", () => {
-        assert.deepEqual(
+        assert.deepStrictEqual(
             Stream.iterate(0,i=>i+1).take(86016).toArray(),
             Stream.iterate(0,i=>i+1).take(86015).toVector().appendAll([86015]).toArray());
     });


### PR DESCRIPTION
Vector tests still refer to the `_content` property, which no longer exists. Due to this fact some tests which should fail pass. There are no bugs in the implementation, only some tests are outdated.