### PR TITLE
Provide operations insert and insertAll from funkia list

### DIFF
--- a/benchmarks/bench.ts
+++ b/benchmarks/bench.ts
@@ -91,6 +91,7 @@ function _compare(preReqs: Prerequisites, items: Array<[string, (x:Prerequisites
         console.log('Fastest is ' + this.filter('fastest').map('name') + "\n");
     }).run();
 }
+
 function compare(...items: Array<[string, (x:Prerequisites)=>any]>) {
     for (let i=0;i<lengths.length;i++) {
         let length = lengths[i];
@@ -286,6 +287,31 @@ compare(['Vector.appendAll', (p:Prerequisites) => p.vec.appendAll(p.vec)],
 compare(['Vector.prependAll', (p:Prerequisites) => p.vec.prependAll(p.vec)],
         ['Array.prependAll', (p:Prerequisites) => p.array.concat(p.array)],
         ['LinkedList.prependAll', (p:Prerequisites) => p.list.prependAll(p.list)]);
+
+compare(['Vector.insert', (p:Prerequisites) => {
+        let v = p.vec;
+        p.array.forEach(elt => {
+            v = v.insert(p.idxThreeQuarters, elt);
+        })
+    }],
+    ['Array.splice single element', (p:Prerequisites) => {
+        let v = p.array.slice();
+        p.array.forEach(elt => {
+            v.splice(p.idxThreeQuarters, 0, elt);
+        })
+    }],
+    //The insert operation for Immutable.js list is linear, and consequently much too slow to test for 10000 elements
+    ['Funkia.insert', (p:Prerequisites) => {
+        let v = p.funkiaList;
+        p.array.forEach(elt => {
+            v = Funkia.insert(p.idxThreeQuarters, elt, v);
+        });
+    }]);
+
+compare(['Vector.insertAll', (p:Prerequisites) => p.vec.insertAll(p.idxThreeQuarters, p.array)],
+    ['Array.splice multiple elements', (p:Prerequisites) => p.array.slice().splice(p.idxThreeQuarters, 0, ...p.array)],
+    ['immList.splice multiple elements', (p:Prerequisites) => p.immList.splice(p.idxThreeQuarters, ...p.array)],
+    ['Funkia.insertAll', (p:Prerequisites) => Funkia.insertAll(p.idxThreeQuarters, p.funkiaList, Funkia.from(p.array))]);
 
 compare(['Vector.foldLeft', (p:Prerequisites) => p.vec.foldLeft(0, (acc,i)=>acc+i)],
         ['Array.foldLeft', (p:Prerequisites) => p.array.reduce((acc,i)=>acc+i)],

--- a/src/Vector.ts
+++ b/src/Vector.ts
@@ -751,6 +751,20 @@ export class Vector<T> implements Seq<T> {
     }
 
     /**
+     * Insert an element at the given index in the list
+     */
+    insert(index: number, elt: T): Vector<T> {
+        return new Vector(L.insert(index, elt, this._list));
+    }
+
+    /**
+     * Insert multiple elements at the given index in the list
+     */
+    insertAll(index: number, elts: Iterable<T>): Vector<T> {
+        return new Vector(L.insertAll(index, L.from(elts), this._list));
+    }
+
+    /**
      * Removes the first element matching the predicate
      * (use [[Seq.filter]] to remove all elements matching a predicate)
      */

--- a/tests/Vector.ts
+++ b/tests/Vector.ts
@@ -138,6 +138,74 @@ describe("Vector.appendAll() implementation", () => {
             Stream.iterate(0,i=>i+1).take(86015).toVector().appendAll([86015]).toArray());
     });
 });
+
+function checkInsert<T>(base: Vector<T>, index: number, toInsert: T, combined: Vector<T>) {
+    const arrayBefore = base.toArray();
+    assert.deepStrictEqual(
+        combined.toArray(),
+        base.insert(index, toInsert).toArray());
+    // inserting should not have modified the original vector
+    assert.deepStrictEqual(arrayBefore, base.toArray());
+}
+
+describe("Vector.insert() implementation", () => {
+    it("handles simple cases correctly", () => {
+        checkInsert(Vector.of(1,2,3,4,5,6), 2, 7, Vector.of(1,2,7,3,4,5,6));
+    });
+    it("Handles correctly insertion into a long vector", () => {
+        checkInsert(
+            Vector.ofIterable(Stream.iterate(1, i=>i+1).take(100)).appendAll(Stream.iterate(102, i=>i+1).take(100)),
+           100, 101, Vector.ofIterable(Stream.iterate(1, i=>i+1).take(201)));
+    });
+    it("Handles insertion to the beginning", () => {
+        checkInsert(
+            Vector.ofIterable(Stream.iterate(1, i=>i+1).take(100)),
+            0, 0, Vector.ofIterable(Stream.iterate(0, i=>i+1).take(101)));
+    });
+    it("Handles insertion to the end", () => {
+        checkInsert(
+            Vector.ofIterable(Stream.iterate(1, i=>i+1).take(100)),
+            100, 101, Vector.ofIterable(Stream.iterate(1, i=>i+1).take(101)));
+    });
+});
+
+function checkInsertAll<T>(base: Vector<T>, index: number, toInsert: Iterable<T>, combined: Vector<T>) {
+    const arrayBefore = base.toArray();
+    assert.deepStrictEqual(
+        combined.toArray(),
+        base.insertAll(index, toInsert).toArray());
+    // inserting should not have modified the original vector
+    assert.deepStrictEqual(arrayBefore, base.toArray());
+}
+
+describe("Vector.insertAll() implementation", () => {
+    it("handles simple cases correctly", () => {
+        checkInsertAll(Vector.of(1,2,3,4,5,6), 2, [7,8], Vector.of(1,2,7,8,3,4,5,6));
+    });
+    it("handles insertion of a long iterable", () => {
+        checkInsertAll(Vector.of(1,72,73), 1, Stream.iterate(2,i=>i+1).take(70),
+            Vector.ofIterable(Stream.iterate(1,i=>i+1).take(73)));
+    });
+    it("handles adding an array", () => {
+        checkInsertAll(Vector.of(1,72,73), 1, Stream.iterate(2,i=>i+1).take(70).toArray(),
+            Vector.ofIterable(Stream.iterate(1,i=>i+1).take(73)));
+    });
+    it("handles adding a vector", () => {
+        checkInsertAll(Vector.of(1,72,73), 1, Stream.iterate(2,i=>i+1).take(70).toVector(),
+            Vector.ofIterable(Stream.iterate(1,i=>i+1).take(73)));
+    });
+    it("Handles insertion to the beginning", () => {
+        checkInsertAll(
+            Vector.ofIterable(Stream.iterate(101, i=>i+1).take(100)),
+            0, Stream.iterate(1, i=>i+1).take(100), Vector.ofIterable(Stream.iterate(1, i=>i+1).take(200)));
+    });
+    it("Handles insertion to the end", () => {
+        checkInsertAll(
+            Vector.ofIterable(Stream.iterate(1, i=>i+1).take(100)),
+            100, Stream.iterate(101, i=>i+1).take(100), Vector.ofIterable(Stream.iterate(1, i=>i+1).take(200)));
+    });
+});
+
 describe("static Vector.zip", () => {
     const r = Vector.zip<[number,string,number]>([1,2], ["a", "b"], Vector.of(11,10,9));
     assert.equal(2, r.length());


### PR DESCRIPTION
I propose implementing missing operations from funkia list, so that the prelude-ts vector takes full advantage of its strengths. In this commit I've delegated `insert` and `insertAll` to funkia list. If you concur with this approach, there are a few further operations which we could add to vector, such as `slice`.