### PR TITLE
Add `Option.orCall(f)` function

### DIFF
--- a/src/Option.ts
+++ b/src/Option.ts
@@ -620,6 +620,14 @@ export class Some<T> implements Value {
         return Either.right<L,T>(this.value);
     }
 
+    /**
+     * If this is a Some, return this object.
+     * If this is a None, return the result of the function.
+     */
+    orCall(_: () => Option<T>): Option<T> {
+      return this;
+    }
+
     hasTrueEquality<T>(): boolean {
         return optionHasTrueEquality(this);
     }
@@ -894,6 +902,14 @@ export class None<T> implements Value {
      */
     toEither<L>(left: L): Either<L,T> {
         return Either.left<L,T>(left);
+    }
+
+    /**
+     * If this is a Some, return this object.
+     * If this is a None, return the result of the function.
+     */
+    orCall(fn: () => Option<T>): Option<T> {
+      return fn();
     }
 
     hasTrueEquality<T>(): boolean {

--- a/tests/Option.ts
+++ b/tests/Option.ts
@@ -53,6 +53,12 @@ describe("option transformation", () => {
     it("should transform with map", () => {
         assert.ok(Option.of(5).equals(Option.of(4).map(x=>x+1)));
     });
+    it("should return the original Some with orCall", () => {
+        assert.ok(Option.of(5).equals(Option.of(5).orCall(() => Option.none())));
+    });
+    it("should call the function when calling orCall on None", () => {
+        assert.ok(Option.of(5).equals(Option.none<number>().orCall(() => Option.of(5))));
+    });
     it("should handle null as Some", () =>
        assert.ok(Option.of(5).map<number|null>(x => null).equals(Option.of<number|null>(null))));
     it("should transform a Some to string properly", () =>
@@ -155,7 +161,7 @@ describe("option retrieval", () => {
        assert.equal(5, Option.of(5).getOrThrow()));
     it("should throw on None.getOrThrow", () =>
        assert.throws(() => Option.none().getOrThrow()));
-    it("should throw on None.getOrThrow with custom msg", () => 
+    it("should throw on None.getOrThrow with custom msg", () =>
         assert.throws(() => Option.none().getOrThrow("my custom msg"),
                       (err: Error) => err.message === 'my custom msg'));
     it("should offer get() if i checked for isSome", () => {


### PR DESCRIPTION
This is like `getOrCall`, but does not unwrap a `Some`     .

It behaves like this:

```typescript
Option.some(1).orCall(() => Option.some(9)) // Option.some(1)
Option.none().orCall(() => Option.some(1))  // Option.some(1)
```

Among other places, this method is useful when calling a recursive function that returns `Option<T>`. Instead of doing something like this:

```typescript
function recurse(): Option<T> {
  const option = Option.of(something);
  if(option.isSome()){
    return option;
  } else {
    return recurse(somethingElse);
  }
}
```

...it can now be written like this, matching ts-prelude's fluent style:

```typescript
function recurse(): Option<T> {
  const option = Option.of(something);
  return option.maybe(() => {
    recurse(somethingElse);
  });
}
```