### PR TITLE
Support values implementing HasEquals in HashMap.hashCode()

### DIFF
--- a/src/HashMap.ts
+++ b/src/HashMap.ts
@@ -618,7 +618,7 @@ export class HashMap<K,V> implements IMap<K,V> {
     hashCode(): number {
         return this.hamt.fold(
             (acc: number, value: V, key: K & WithEquality) =>
-                acc + fieldsHashCode([key, value]), 0);
+                acc + fieldsHashCode(key, value), 0);
     }
 
     /*

--- a/tests/HashMap.ts
+++ b/tests/HashMap.ts
@@ -5,7 +5,7 @@ import { LinkedList } from "../src/LinkedList";
 import { Option } from "../src/Option";
 import { Stream } from "../src/Stream";
 import { Tuple2 } from "../src/Tuple2";
-import { fieldsHashCode } from "../src/Comparison";
+import { fieldsHashCode, HasEquals, getHashCode } from "../src/Comparison";
 import { MyClass} from "./SampleData";
 import { assertFailCompile } from "./TestHelpers";
 import * as assert from 'assert'
@@ -152,6 +152,26 @@ describe("hashmap equality", () => {
     it("should not have trivial hashcode collisions #2", () =>
         assert.equal(false, HashMap.of(["48", 1], ["49", 2], ["50", 3], ["51", 4]).hashCode()
             == HashMap.of(["49345678", 2], ["50", 3], ["51", 4]).hashCode()));
+    it("should generate hashCodes for values implementing HasEquals", () => {
+        class TestClass implements HasEquals {
+            constructor(
+                public value: string
+            ) {}
+
+            public equals(other: unknown): boolean {
+                return this.hashCode() === getHashCode(other);
+            }
+
+            public hashCode(): number {
+                return fieldsHashCode(this.value)
+            }
+        }
+
+        const a = HashMap.of(["48", new TestClass("foo")]).hashCode();
+        const b = HashMap.of(["48", new TestClass("bar")]).hashCode();
+
+        assert.equal(false, a == b);
+    });
 })
 
 describe("hashmap - toString should be nicely formatted", () => {


### PR DESCRIPTION
Hi! After your fix for the HashMap, I was still having some issues when comparing two changed maps when the values were complex classes, even though I did have HasEquals implemented.

After some debugging, I found out that on this [line], a hash code would be generated for the string `[4,[object Object]]` instead of taking into account the value's actual hash code.

I hope this fix for it is ok! Since `fieldsHashCode` collects all arguments passed to it, this should be fine. Of course, plain objects that don't implement `HasEquals` will still not generate a sensible hash code.

Thanks again!

[line]: https://github.com/emmanueltouzery/prelude-ts/blob/20fb3fc971859eab02540e18387eeb17d585c432/src/Comparison.ts#L125