### PR TITLE
Switch custom node object inspection to use Symbol.for

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8.11.1
+      - image: cimg/node:12.22
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/src/Value.ts
+++ b/src/Value.ts
@@ -5,8 +5,7 @@ import * as util from 'util';
 /**
  * @hidden
  */
-// @ts-ignore -- see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30241
-export const inspect: unique symbol = util.inspect.custom;
+export const inspect = Symbol.for("nodejs.util.inspect.custom");
 
 export interface Value {
 

--- a/tests/Vector.ts
+++ b/tests/Vector.ts
@@ -6,6 +6,7 @@ import { Option } from "../src/Option";
 import { assertFailCompile } from "./TestHelpers";
 import * as SeqTest from "./Seq";
 import * as assert from 'assert'
+import * as util from "util";
 
 SeqTest.runTests("Vector",
                  Vector.ofIterable,
@@ -22,6 +23,9 @@ describe("Vector toString", () => {
         "Vector({field1: hi, field2: 99})", Vector.of(new MyClass("hi", 99)).toString()));
     it("serializes to string correctly - plain map", () => assert.equal(
         "Vector({\"name\":\"hi\",\"age\":99})", Vector.of({name:"hi", age:99}).toString()));
+    it("supports util.inspect on node", () =>
+      assert.equal("Vector(1, 2, 3)", util.inspect(Vector.of(1, 2, 3)))
+    );
 });
 
 // tests with over 32 elements


### PR DESCRIPTION
util.inspect.custom is a symbol provided by node which allows custom
printing in the repl but is not available in the browser.  Bundlers
like webpack polyfill this by default but other bundlers like vite
do not (although vite can be configured to polyfill it).  But, to
avoid the need to polyfill at all, nodejs also exposes the symbol at
Symbol.for("nodejs.util.inspect.custom") on node v11 and up.

https://nodejs.org/api/util.html#util_util_inspect_custom

To avoid the need to polyfill, switch Value.ts to call
Symbol.for("nodejs.util.inspect.custom").  In node, this will use the
correct symbol to allow inspection and printing on the repl, while
in the browser it will create a new harmless symbol. As an added
benefit, the return type of Symbol.for is already a unique symbol so no
need for the explicit definition.

Note that Symbol.for is not available in IE11 and will need to be
polyfilled if you want to still support IE11.

Fixes #52 