### PR TITLE
Enable usage as an npm github dependency

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+# Required so that built files are included when using this github repo directly as an npm dependency
+#
+# See https://stackoverflow.com/questions/40528053/npm-install-and-build-of-forked-github-repo/57829251#57829251
+# for more details.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     },
     "homepage": "https://github.com/emmanueltouzery/prelude.ts#readme",
     "scripts": {
-        "prepublish": "npm run clean; scripts/prepublish.sh",
+        "prepare": "npm run clean; scripts/prepublish.sh",
         "test": "rm -f tests/apidoc-*; tsc -p tsconfig.test.json && node ./dist/tests/Comments.js && tsc -p tsconfig.test.json && ./node_modules/mocha/bin/mocha --throw-deprecation --timeout 60000 ./dist/tests/*.js",
         "clean": "rm -f tests/apidoc-*; rm -Rf ./dist",
         "docgen": "./scripts/make_doc.sh",


### PR DESCRIPTION
That is, with this we can add the github repo as a dependency without packagining and pushing to npm.

The changes are based on https://stackoverflow.com/questions/40528053/npm-install-and-build-of-forked-github-repo/57829251#57829251