### PR TITLE
Throw an Error instead of a string when there's a contract violation

### DIFF
--- a/src/Contract.ts
+++ b/src/Contract.ts
@@ -1,7 +1,7 @@
 import { hasTrueEquality } from "./Comparison";
 import { toStringHelper } from "./SeqHelpers";
 
-let preludeTsContractViolationCb = (msg:string):void => { throw msg; };
+let preludeTsContractViolationCb = (msg:string):void => { throw new Error(msg); };
 
 /**
  * Some programmatic errors are only detectable at runtime


### PR DESCRIPTION
Change the default to throw an Error when there's a contact violation

As described in https://github.com/emmanueltouzery/prelude-ts/issues/59, this means that we get stack traces in testing environments when preludeTsContractViolationCb is called.