### PR TITLE
Switch pipeline to npm and watch package-lock for dependency cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: yarn install
+      - run: npm install
 
       - save_cache:
           paths:
@@ -34,10 +34,10 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       # run tests!
-      - run: yarn test
+      - run: npm test
 
       # apidoc generation can easily fail -- check it.
-      - run: yarn run docgen
+      - run: npm run docgen
 
       # check for bad links in the apidocs
       - run: sh -c "! grep -r \"\[\[\w\" apidoc/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
+          - v1-dependencies-{{ checksum "package-lock.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
@@ -31,7 +31,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v1-dependencies-{{ checksum "package-lock.json" }}
 
       # run tests!
       - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "prelude-ts",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "homepage": "https://github.com/emmanueltouzery/prelude.ts#readme",
     "scripts": {
         "prepare": "npm run clean; scripts/prepublish.sh",
-        "test": "rm -f tests/apidoc-*; tsc -p tsconfig.test.json && node ./dist/tests/Comments.js && tsc -p tsconfig.test.json && ./node_modules/mocha/bin/mocha --throw-deprecation --timeout 60000 ./dist/tests/*.js",
+        "test": "rm -f tests/apidoc-*; tsc -p tsconfig.test.json && node ./dist/tests/Comments.js && tsc -p tsconfig.test.json && ./node_modules/mocha/bin/mocha --throw-deprecation --timeout 90000 ./dist/tests/*.js",
         "clean": "rm -f tests/apidoc-*; rm -Rf ./dist",
         "docgen": "./scripts/make_doc.sh",
         "benchmarks": "tsc -p tsconfig.benchmarks.json && node ./dist/benchmarks/bench.js"


### PR DESCRIPTION
Small change to use npm instead of yarn in the pipeline, since I think that's what's actually used by contributors (guessing from the comments in https://github.com/emmanueltouzery/prelude-ts/issues/66) 

I also changed the cache to look at the package lock instead, as doing so is more accurate now that the lock file is in the repo :)